### PR TITLE
Fix undefined OPEN_MAX error

### DIFF
--- a/src/closefrom.cpp
+++ b/src/closefrom.cpp
@@ -154,6 +154,10 @@ int libclf_closefrom(int fd0)
 
 static int closefrom_maxfd = -1;
 
+#ifndef OPEN_MAX
+#define OPEN_MAX 256 /* Guess */
+#endif
+
 void libclf_setmaxfd(int max)
 {
     closefrom_maxfd = max;


### PR DESCRIPTION
Not all systems define POSIX.1 value OPEN_MAX. In this case just close
all descriptors up to some arbitrary limit - say 256 [1].

[1]
Advanced Programming in the UNIX Environment, Richard Stevens, p. 52.