### PR TITLE
Add conditional check for __linux__

### DIFF
--- a/src/closefrom.cpp
+++ b/src/closefrom.cpp
@@ -111,7 +111,7 @@ int libclf_closefrom(int fd0)
 }
 
 /*************************************************************************/
-#elif (defined(linux) || defined(__linux))
+#elif (defined(linux) || defined(__linux) || defined(__linux__))
 
 /* Use /proc/self/fd directory */
 #include <sys/types.h>

--- a/src/mpdcli.hxx
+++ b/src/mpdcli.hxx
@@ -86,7 +86,8 @@ public:
 class MPDCli {
 public:
     MPDCli(const std::string& host, int port = 6600, 
-           const std::string& pass="");
+           const std::string& pass="", const std::string& m_onstart="",
+           const std::string& m_onstop="");
     ~MPDCli();
     bool ok() {return m_ok && m_conn;}
     bool setVolume(int ivol, bool isMute = false);
@@ -134,6 +135,8 @@ private:
     std::string m_host;
     int m_port;
     std::string m_password;
+    std::string m_onstart;
+    std::string m_onstop;
     regex_t m_tpuexpr;
     // addtagid command only exists for mpd 0.19 and later.
     bool m_have_addtagid; 

--- a/src/upmpd.cxx
+++ b/src/upmpd.cxx
@@ -275,6 +275,8 @@ int main(int argc, char *argv[])
 
     string iconpath;
     string cachedir;
+    string onstart;
+    string onstop;
     if (!g_configfilename.empty()) {
         ConfSimple config(g_configfilename.c_str(), 1, true);
         if (!config.ok()) {
@@ -306,6 +308,8 @@ int main(int argc, char *argv[])
         config.get("iconpath", iconpath);
         config.get("presentationhtml", presentationhtml);
         config.get("cachedir", cachedir);
+        config.get("onstart", onstart);
+        config.get("onstop", onstop);
         if (!(op_flags & OPT_i)) {
             config.get("upnpiface", iface);
             if (iface.empty()) {
@@ -435,7 +439,7 @@ int main(int argc, char *argv[])
     MPDCli *mpdclip = 0;
     int mpdretrysecs = 2;
     for (;;) {
-        mpdclip = new MPDCli(mpdhost, mpdport, mpdpassword);
+        mpdclip = new MPDCli(mpdhost, mpdport, mpdpassword, onstart, onstop);
         if (mpdclip == 0) {
             LOGFAT("Can't allocate MPD client object" << endl);
             return 1;

--- a/src/upmpdcli.conf
+++ b/src/upmpdcli.conf
@@ -46,6 +46,16 @@ ohmetapersist = 1
 # started as root
 # cachedir = /var/lib/upmpdcli
 
+# Run a command when playback is about to begin. Specify the full path to the
+# program, e.g. /usr/bin/logger. Executable scripts work, but must have a
+# #!/bin/sh (or whatever) in the headline.
+# onstart =
+
+# Run a command when playback is about to end. Specify the full path to the
+# program, e.g. /usr/bin/logger. Executable scripts work, but must have a
+# #!/bin/sh (or whatever) in the headline.
+# onstop =
+
 # Mimimum interval (Seconds) between 2 saves of the cache. Setting this may
 # improve playlist load speed on a slow device. The default is to start a
 # new save as soon as the previous one is done (if the list changed again


### PR DESCRIPTION
When building upmpdcli with certain toolchains using the compiler flag `-std=c++0x` let gcc not define `linux` or `__linux`, but `__linux__`.