### PR TITLE
Minor fixes and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 *.la
 *.lo
 *.o
+.autotools
+.cproject
 .deps
 .dirstamp
 .libs
+.project
+.settings
 Makefile
 Makefile.in
 aclocal.m4

--- a/doc/upmpdcli.txt
+++ b/doc/upmpdcli.txt
@@ -59,6 +59,8 @@ The following parameters can be set:
 note>>|||iconpath
 |Path to HTML file to be used as presentation
 page. <<upmpdcli.presentationnote,See note>>|||presentationhtml
+|Run a command (or shell script) when playback is about to begin.|||onstart
+|Run a command (or shell script) when playback is about to end.|||onstop
 |===========================    
 
 [[upmpdcli.iconpathnote]]

--- a/src/httpfs.cxx
+++ b/src/httpfs.cxx
@@ -201,7 +201,7 @@ bool initHttpFs(unordered_map<string, VDirContent>& files,
     string presentationdata;
     if (!presentationhtml.empty()) {
         if (!file_to_string(presentationhtml, presentationdata, &reason)) {
-            LOGERR("Failed reading " << iconpath << " : " << reason << endl);
+            LOGERR("Failed reading " << presentationhtml << " : " << reason << endl);
         }
     }
 

--- a/src/upmpd.cxx
+++ b/src/upmpd.cxx
@@ -210,6 +210,7 @@ int main(int argc, char *argv[])
     bool ohmetapersist = true;
     string upmpdcliuser("upmpdcli");
     string pidfilename("/var/run/upmpdcli.pid");
+    string iconpath(DATADIR "/icon.png");
     string presentationhtml(DATADIR "/presentation.html");
     string iface;
     unsigned short upport = 0;

--- a/src/upmpdcli.conf
+++ b/src/upmpdcli.conf
@@ -22,6 +22,10 @@
 # Log level. 0-4. Can also be specified as -l loglevel.
 #loglevel = 3
 
+# You can set a path to an icon here. The icon will be displayed by a control
+# point. The icon will only be read once, when upmpdcli starts up.
+# iconpath = /usr/share/upmpdcli/icon.png
+
 # You can set a path to an html file here, to replace the default
 # presentation page. The page will only be read once, when upmpdcli starts
 # up.


### PR DESCRIPTION
* Fix wrong path shown in the `presentationhtml` error message
* Add a default icon path for `iconpath` as documented
* Document `onstart` and `onstop`
* Ignore some more files