### PR TITLE
Add onvolumechange

### DIFF
--- a/doc/upmpdcli.txt
+++ b/doc/upmpdcli.txt
@@ -61,6 +61,7 @@ note>>|||iconpath
 page. <<upmpdcli.presentationnote,See note>>|||presentationhtml
 |Run a command (or shell script) when playback is about to begin.|||onstart
 |Run a command (or shell script) when playback is about to end.|||onstop
+|Run a command (or shell script) when volume is changed.|||onvolumechange
 |===========================    
 
 [[upmpdcli.iconpathnote]]

--- a/src/mpdcli.hxx
+++ b/src/mpdcli.hxx
@@ -87,7 +87,8 @@ class MPDCli {
 public:
     MPDCli(const std::string& host, int port = 6600, 
            const std::string& pass="", const std::string& m_onstart="",
-           const std::string& m_onstop="");
+           const std::string& m_onstop="",
+           const std::string& m_onvolumechange="");
     ~MPDCli();
     bool ok() {return m_ok && m_conn;}
     bool setVolume(int ivol, bool isMute = false);
@@ -137,6 +138,7 @@ private:
     std::string m_password;
     std::string m_onstart;
     std::string m_onstop;
+    std::string m_onvolumechange;
     regex_t m_tpuexpr;
     // addtagid command only exists for mpd 0.19 and later.
     bool m_have_addtagid; 

--- a/src/upmpd.cxx
+++ b/src/upmpd.cxx
@@ -279,6 +279,7 @@ int main(int argc, char *argv[])
     string cachedir;
     string onstart;
     string onstop;
+    string onvolumechange;
     if (!g_configfilename.empty()) {
         ConfSimple config(g_configfilename.c_str(), 1, true);
         if (!config.ok()) {
@@ -315,6 +316,7 @@ int main(int argc, char *argv[])
         config.get("cachedir", cachedir);
         config.get("onstart", onstart);
         config.get("onstop", onstop);
+        config.get("onvolumechange", onvolumechange);
         if (!(op_flags & OPT_i)) {
             config.get("upnpiface", iface);
             if (iface.empty()) {
@@ -444,7 +446,8 @@ int main(int argc, char *argv[])
     MPDCli *mpdclip = 0;
     int mpdretrysecs = 2;
     for (;;) {
-        mpdclip = new MPDCli(mpdhost, mpdport, mpdpassword, onstart, onstop);
+        mpdclip = new MPDCli(mpdhost, mpdport, mpdpassword, onstart, onstop,
+                             onvolumechange);
         if (mpdclip == 0) {
             LOGFAT("Can't allocate MPD client object" << endl);
             return 1;

--- a/src/upmpdcli.conf
+++ b/src/upmpdcli.conf
@@ -64,6 +64,13 @@ ohmetapersist = 1
 # #!/bin/sh (or whatever) in the headline.
 # onstop =
 
+# Run a command when volume is changed. Specify the full path to the program,
+# e.g. /usr/bin/logger. Executable scripts work, but must have a #!/bin/sh (or
+# whatever) in the headline.
+# The command is called with the volume as the first argument, e.g.
+# <command> 85.
+# onvolumechange =
+
 # Mimimum interval (Seconds) between 2 saves of the cache. Setting this may
 # improve playlist load speed on a slow device. The default is to start a
 # new save as soon as the previous one is done (if the list changed again


### PR DESCRIPTION
Add an onvolumechange config option. This option can be set in the configuration
file to run a command or script when the volume is changed. The command or
script will be called with the volume as the first argument.

A use case for this might be to display the new volume level on a LCD display
connected to the media renderer.

Note that the full path for the command or script has to be specified, e.g.
'/usr/bin/logger'. Executable shell scripts must begin with a shebang, e.g.
'#!/bin/sh'.