### PR TITLE
Onplay

### DIFF
--- a/doc/upmpdcli.txt
+++ b/doc/upmpdcli.txt
@@ -62,8 +62,12 @@ page. <<upmpdcli.presentationnote,See note>>|||presentationhtml
 |Run a command (or shell script) when a play action is performed. The difference
   to onplay is that onstart is called *before* playback is about to begin.|||
   onstart
-|Run a command (or shell script) when playback is about to begin.|||onplay
-|Run a command (or shell script) when playback is about to end.|||onstop
+|Run a command (or shell script) when MPD playback is about to begin. Note that
+  onstart is also called if MPD is controlled from another tool, e.g. by mpc.|||
+  onplay
+|Run a command (or shell script) when MPD playback is about to end. Note that
+  onstart is also called if MPD is controlled from another tool, e.g. by mpc.|||
+  onstop
 |Run a command (or shell script) when volume is changed.|||onvolumechange
 |===========================    
 

--- a/doc/upmpdcli.txt
+++ b/doc/upmpdcli.txt
@@ -59,7 +59,10 @@ The following parameters can be set:
 note>>|||iconpath
 |Path to HTML file to be used as presentation
 page. <<upmpdcli.presentationnote,See note>>|||presentationhtml
-|Run a command (or shell script) when playback is about to begin.|||onstart
+|Run a command (or shell script) when a play action is performed. The difference
+  to onplay is that onstart is called *before* playback is about to begin.|||
+  onstart
+|Run a command (or shell script) when playback is about to begin.|||onplay
 |Run a command (or shell script) when playback is about to end.|||onstop
 |Run a command (or shell script) when volume is changed.|||onvolumechange
 |===========================    

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -220,6 +220,7 @@ int main(int argc, char *argv[])
 
     string cachedir;
     string onstart;
+    string onplay;
     string onstop;
     string onvolumechange;
     if (!g_configfilename.empty()) {
@@ -258,6 +259,7 @@ int main(int argc, char *argv[])
         g_config->get("presentationhtml", presentationhtml);
         g_config->get("cachedir", cachedir);
         g_config->get("onstart", onstart);
+        g_config->get("onplay", onplay);
         g_config->get("onstop", onstop);
         g_config->get("onvolumechange", onvolumechange);
         if (!(op_flags & OPT_i)) {
@@ -420,8 +422,8 @@ int main(int argc, char *argv[])
     MPDCli *mpdclip = 0;
     int mpdretrysecs = 2;
     for (;;) {
-        mpdclip = new MPDCli(mpdhost, mpdport, mpdpassword, onstart, onstop,
-                             onvolumechange);
+        mpdclip = new MPDCli(mpdhost, mpdport, mpdpassword, onstart, onplay,
+                             onstop, onvolumechange);
         if (mpdclip == 0) {
             LOGFAT("Can't allocate MPD client object" << endl);
             return 1;

--- a/src/mpdcli.cxx
+++ b/src/mpdcli.cxx
@@ -167,7 +167,8 @@ bool MPDCli::updStatus()
     switch (mpd_status_get_state(mpds)) {
     case MPD_STATE_STOP:
         // Only execute onstop command if mpd was playing or paused
-        if (m_stat.state != MpdStatus::MPDS_STOP && !m_onstop.empty()) {
+        if (!m_onstop.empty() && (m_stat.state == MpdStatus::MPDS_PLAY ||
+                                  m_stat.state == MpdStatus::MPDS_PAUSE)) {
             if (system(m_onstop.c_str())) {
                 LOGERR("MPDCli::updStatus: " << m_onstop << " failed "<< endl);
             }

--- a/src/mpdcli.hxx
+++ b/src/mpdcli.hxx
@@ -95,7 +95,7 @@ class MPDCli {
 public:
     MPDCli(const std::string& host, int port = 6600, 
            const std::string& pass="", const std::string& m_onstart="",
-           const std::string& m_onstop="",
+           const std::string& m_onplay="", const std::string& m_onstop="",
            const std::string& m_onvolumechange="");
     ~MPDCli();
     bool ok() {return m_ok && m_conn;}
@@ -150,6 +150,7 @@ private:
     int m_port;
     std::string m_password;
     std::string m_onstart;
+    std::string m_onplay;
     std::string m_onstop;
     std::string m_onvolumechange;
     regex_t m_tpuexpr;

--- a/src/upmpdcli.conf-dist
+++ b/src/upmpdcli.conf-dist
@@ -59,6 +59,11 @@ ohmetapersist = 1
 # #!/bin/sh (or whatever) in the headline.
 # onstart =
 
+# Run a command when playback is about to begin. Specify the full path to the
+# program, e.g. /usr/bin/logger. Executable scripts work, but must have a
+# #!/bin/sh (or whatever) in the headline.
+# onplay =
+
 # Run a command when playback is about to end. Specify the full path to the
 # program, e.g. /usr/bin/logger. Executable scripts work, but must have a
 # #!/bin/sh (or whatever) in the headline.


### PR DESCRIPTION
Add a new option *onplay* for running commands or shell scripts when MPD playback is about to begin. Together with *onstop* these options can be used to run some actions depending on the state of MPD. On the other hand, the option *onstart* can be used to run some actions immediately after a "play" user action is received, e.g. a "Play" button press in upplay.

The usual order of the run scripts is:
1) onstart: upmpdcli receives an "Play" action and calls MPD to play the source
2) onplay: MPD playback is about to begin
3) onstop: MPD playback is about to end

Note that the *onstart* and *onstop* actions are also executed if upmpdcli is running and MPD is controlled by another tool, e.g. mpc.

Note that *onstop* is executed if a "stop" action is received **and** if a song or playlist ends.