### PR TITLE
Use libupnpp/log.hxx as include path in plgwithslave.cxx

### DIFF
--- a/src/mediaserver/cdplugins/plgwithslave.cxx
+++ b/src/mediaserver/cdplugins/plgwithslave.cxx
@@ -35,7 +35,7 @@
 #include "cmdtalk.h"
 #include "pathut.h"
 #include "smallut.h"
-#include "log.hxx"
+#include "libupnpp/log.hxx"
 #include "main.hxx"
 #include "conftree.h"
 


### PR DESCRIPTION
Make it consistent with all other header includes of log.hxx. Otherwise, build fails using the pkg-config file of libupnpp, because of the header path issue discussed in #46.