### PR TITLE
Fix unsafe header path when cross-compiling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = -DDEBUG -g -Wall \
-            -I${prefix}/include/libupnpp \
+            $(upnpp_CFLAGS) \
             -I$(top_srcdir)/src \
             -DDATADIR=\"${pkgdatadir}\" -DCONFIGDIR=\"${sysconfdir}\"
 

--- a/configure.ac
+++ b/configure.ac
@@ -35,10 +35,10 @@ dnl AC_CHECK_LIB([upnp], [UpnpInit], [], AC_MSG_ERROR([libupnp not found]))
 dnl AC_CHECK_LIB([curl], [curl_easy_init], [],AC_MSG_ERROR([libcurl not found]))
 dnl AC_CHECK_LIB([expat], [XML_ParserCreate], [],AC_MSG_ERROR([libexpat not found]))
 
-AC_CHECK_LIB([upnpp], [getsyshwaddr], [], [AC_MSG_ERROR([libupnpp])])
+PKG_CHECK_MODULES([upnpp], [libupnpp], [], [AC_MSG_ERROR([libupnpp])])
 AC_CHECK_LIB([mpdclient], [mpd_connection_new], [],
                           AC_MSG_ERROR([libmpdclient not found]))
-SCCTL_LIBS=$LIBS
+SCCTL_LIBS="$LIBS $upnpp_LIBS"
 
 AC_CHECK_LIB([microhttpd], [MHD_queue_response], [], [])
 
@@ -56,8 +56,8 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM(
     [AC_MSG_ERROR([libjsoncpp not found.])])
 AC_LANG_POP
 
-UPMPDCLI_LIBS=$LIBS
-echo "UPMPDCLI_LIBS=$LIBS"
+UPMPDCLI_LIBS="$LIBS $upnpp_LIBS"
+echo "UPMPDCLI_LIBS=$UPMPDCLI_LIBS"
 
 LIBS=""
 


### PR DESCRIPTION
Building upmpdcli aborts because of an unsafe header inclusion of `/usr/include/libupnpp`. Using `{prefix}` to get the header path is wrong for cross-compilation.

Instead of hard-coding the flags for libupnpp use pkg-config
to get the correct ones.

Closes #45