### PR TITLE
Use pkg-config for jsoncpp, libmpdclient and libmicrohttpd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 AM_CPPFLAGS = -DDEBUG -g -Wall \
-            $(upnpp_CFLAGS) \
+            $(upnpp_CFLAGS)  $(libmpdclient_CFLAGS) $(libmicrohttpd_CFLAGS) \
+            $($jsoncpp_CFLAGS) \
             -I$(top_srcdir)/src \
             -I$(top_srcdir)/src/mediaserver/cdplugins \
             -DDATADIR=\"${pkgdatadir}\" -DCONFIGDIR=\"${sysconfdir}\"

--- a/configure.ac
+++ b/configure.ac
@@ -36,27 +36,17 @@ dnl AC_CHECK_LIB([curl], [curl_easy_init], [],AC_MSG_ERROR([libcurl not found]))
 dnl AC_CHECK_LIB([expat], [XML_ParserCreate], [],AC_MSG_ERROR([libexpat not found]))
 
 PKG_CHECK_MODULES([upnpp], [libupnpp], [], [AC_MSG_ERROR([libupnpp])])
-AC_CHECK_LIB([mpdclient], [mpd_connection_new], [],
-                          AC_MSG_ERROR([libmpdclient not found]))
-SCCTL_LIBS="$LIBS $upnpp_LIBS"
+PKG_CHECK_MODULES([libmpdclient], [libmpdclient], [],
+	[AC_MSG_ERROR([libmpdclient not found])])
+SCCTL_LIBS="$LIBS $upnpp_LIBS $libmpdclient_LIBS"
 
-AC_CHECK_LIB([microhttpd], [MHD_queue_response], [], AC_MSG_ERROR([libmicrohttpd not found]))
-
-AC_LANG_PUSH([C++])
+PKG_CHECK_MODULES([libmicrohttpd], [libmicrohttpd], [],
+	[AC_MSG_ERROR([libmicrohttpd not found])])
 
 AC_CHECK_HEADERS(json/json.h jsoncpp/json/json.h)
-LIBS="$LIBS -ljsoncpp"
-AC_LINK_IFELSE([AC_LANG_PROGRAM(
-    [[#ifdef HAVE_JSONCPP_JSON_JSON_H
-    #include <jsoncpp/json/json.h>
-    #else
-    #include <json/json.h>
-    #endif]], [Json::Features dummy])],
-    [HAVE_JSONCPP=1],
-    [AC_MSG_ERROR([libjsoncpp not found.])])
-AC_LANG_POP
+PKG_CHECK_MODULES([jsoncpp], [jsoncpp], [], [AC_MSG_ERROR([jsoncpp not found])])
 
-UPMPDCLI_LIBS="$LIBS $upnpp_LIBS"
+UPMPDCLI_LIBS="$LIBS $upnpp_LIBS $libmpdclient_LIBS $libmicrohttpd_LIBS $jsoncpp_LIBS"
 echo "UPMPDCLI_LIBS=$UPMPDCLI_LIBS"
 
 LIBS=""


### PR DESCRIPTION
libmpdclient, libmicrohttpd and jsoncpp provide a .pc file. Use pkg-config for detecting the libraries and for providing the necessary details for compiling and linking.

The current build system of upmpdcli does not use `PKG_CHECK_MODULES`, but `AC_LINK_IFELSE` to detect jsoncpp. After bumping jsoncpp version from 1.7.2 to 1.7.5 the detection fails, because the test program does not compile anymore:

```
In file included from
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/autolink.h:9:0,
                 from
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/json.h:9,
                 from test.c:1:
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/config.h:155:9:
error: 'int64_t' does not name a type
 typedef int64_t Int64;
         ^
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/config.h:156:9:
error: 'uint64_t' does not name a type
 typedef uint64_t UInt64;
         ^
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/config.h:158:9:
error: 'Int64' does not name a type
 typedef Int64 LargestInt;
         ^
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/config.h:159:9:
error: 'UInt64' does not name a type
 typedef UInt64 LargestUInt;
         ^
In file included from
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/json.h:10:0,
                 from test.c:1:
/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include/json/value.h:184:11:
error: 'UInt64' in namespace 'Json' does not name a type
   typedef Json::UInt64 UInt64;

[..]
```

Instead of fixing the test program use `PKG_CHECK_MODULES` to check for jsoncpp. While we're on it, add it for libmpdclient and libmicrohttpd, too.

Closes: #51